### PR TITLE
Fix gen-resources.sh scripts

### DIFF
--- a/fhir-models-gen/gen-resources.sh
+++ b/fhir-models-gen/gen-resources.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 
-wget -O definitions.zip https://www.hl7.org/fhir/definitions.json.zip
+
+go install
+
+# Fix version to R4 for now.
+# As R4B has been released in May 2022, we should update to this or at least
+# allow the option to select the version.
+wget -O definitions.zip https://www.hl7.org/fhir/R4/definitions.json.zip
 unzip definitions.zip profiles-types.json valuesets.json -d fhir
 rm definitions.zip
-wget -O fhir/bundle.json http://hl7.org/fhir/bundle.profile.json
-wget -O fhir/codesystem.json http://hl7.org/fhir/codesystem.profile.json
-wget -O fhir/structuredefinition.json http://hl7.org/fhir/structuredefinition.profile.json
-wget -O fhir/valueset.json http://hl7.org/fhir/valueset.profile.json
+wget -O fhir/bundle.json http://hl7.org/fhir/R4/bundle.profile.json
+wget -O fhir/codesystem.json http://hl7.org/fhir/R4/codesystem.profile.json
+wget -O fhir/structuredefinition.json http://hl7.org/fhir/R4/structuredefinition.profile.json
+wget -O fhir/valueset.json http://hl7.org/fhir/R4/valueset.profile.json
 
 go generate ./fhir

--- a/fhir-models/gen-resources.sh
+++ b/fhir-models/gen-resources.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+set -eu
 
-wget -O definitions.zip https://www.hl7.org/fhir/definitions.json.zip
+# Fix version to R4 for now.
+# As R4B has been released in May 2022, we should update to this or at least
+# allow the option to select the version.
+wget -O definitions.zip https://www.hl7.org/fhir/R4/definitions.json.zip
 unzip definitions.zip profiles-resources.json profiles-types.json valuesets.json -d fhir
 rm definitions.zip
 


### PR DESCRIPTION
* Fail on non-zero exit code
* Set version to R4 to avoid error when R4B is downloaded
* Run `go install` in `fhir-models-gen` to ensure latest generator is
  used