### PR TITLE
Use float64 for decimal type

### DIFF
--- a/fhir-models-gen/cmd/genResources.go
+++ b/fhir-models-gen/cmd/genResources.go
@@ -506,7 +506,7 @@ func typeCodeToTypeIdentifier(typeCode string) string {
 	case "dateTime":
 		return "string"
 	case "decimal":
-		return "string"
+		return "float64"
 	case "id":
 		return "string"
 	case "instant":

--- a/fhir-models-gen/fhir/age.go
+++ b/fhir-models-gen/fhir/age.go
@@ -21,7 +21,7 @@ package fhir
 type Age struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models-gen/fhir/bundle.go
+++ b/fhir-models-gen/fhir/bundle.go
@@ -59,7 +59,7 @@ type BundleEntrySearch struct {
 	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Mode              *SearchEntryMode `bson:"mode,omitempty" json:"mode,omitempty"`
-	Score             *string          `bson:"score,omitempty" json:"score,omitempty"`
+	Score             *float64         `bson:"score,omitempty" json:"score,omitempty"`
 }
 type BundleEntryRequest struct {
 	ID                *string     `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models-gen/fhir/codeSystem.go
+++ b/fhir-models-gen/fhir/codeSystem.go
@@ -106,7 +106,7 @@ type CodeSystemConceptProperty struct {
 	ValueInteger      int         `bson:"valueInteger" json:"valueInteger"`
 	ValueBoolean      bool        `bson:"valueBoolean" json:"valueBoolean"`
 	ValueDateTime     string      `bson:"valueDateTime" json:"valueDateTime"`
-	ValueDecimal      string      `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal      float64     `bson:"valueDecimal" json:"valueDecimal"`
 }
 type OtherCodeSystem CodeSystem
 

--- a/fhir-models-gen/fhir/count.go
+++ b/fhir-models-gen/fhir/count.go
@@ -21,7 +21,7 @@ package fhir
 type Count struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models-gen/fhir/distance.go
+++ b/fhir-models-gen/fhir/distance.go
@@ -21,7 +21,7 @@ package fhir
 type Distance struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models-gen/fhir/duration.go
+++ b/fhir-models-gen/fhir/duration.go
@@ -21,7 +21,7 @@ package fhir
 type Duration struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models-gen/fhir/elementDefinition.go
+++ b/fhir-models-gen/fhir/elementDefinition.go
@@ -45,7 +45,7 @@ type ElementDefinition struct {
 	DefaultValueCode                *string                       `bson:"defaultValueCode,omitempty" json:"defaultValueCode,omitempty"`
 	DefaultValueDate                *string                       `bson:"defaultValueDate,omitempty" json:"defaultValueDate,omitempty"`
 	DefaultValueDateTime            *string                       `bson:"defaultValueDateTime,omitempty" json:"defaultValueDateTime,omitempty"`
-	DefaultValueDecimal             *string                       `bson:"defaultValueDecimal,omitempty" json:"defaultValueDecimal,omitempty"`
+	DefaultValueDecimal             *float64                      `bson:"defaultValueDecimal,omitempty" json:"defaultValueDecimal,omitempty"`
 	DefaultValueID                  *string                       `bson:"defaultValueID,omitempty" json:"defaultValueID,omitempty"`
 	DefaultValueInstant             *string                       `bson:"defaultValueInstant,omitempty" json:"defaultValueInstant,omitempty"`
 	DefaultValueInteger             *int                          `bson:"defaultValueInteger,omitempty" json:"defaultValueInteger,omitempty"`
@@ -97,7 +97,7 @@ type ElementDefinition struct {
 	FixedCode                       *string                       `bson:"fixedCode,omitempty" json:"fixedCode,omitempty"`
 	FixedDate                       *string                       `bson:"fixedDate,omitempty" json:"fixedDate,omitempty"`
 	FixedDateTime                   *string                       `bson:"fixedDateTime,omitempty" json:"fixedDateTime,omitempty"`
-	FixedDecimal                    *string                       `bson:"fixedDecimal,omitempty" json:"fixedDecimal,omitempty"`
+	FixedDecimal                    *float64                      `bson:"fixedDecimal,omitempty" json:"fixedDecimal,omitempty"`
 	FixedID                         *string                       `bson:"fixedID,omitempty" json:"fixedID,omitempty"`
 	FixedInstant                    *string                       `bson:"fixedInstant,omitempty" json:"fixedInstant,omitempty"`
 	FixedInteger                    *int                          `bson:"fixedInteger,omitempty" json:"fixedInteger,omitempty"`
@@ -147,7 +147,7 @@ type ElementDefinition struct {
 	PatternCode                     *string                       `bson:"patternCode,omitempty" json:"patternCode,omitempty"`
 	PatternDate                     *string                       `bson:"patternDate,omitempty" json:"patternDate,omitempty"`
 	PatternDateTime                 *string                       `bson:"patternDateTime,omitempty" json:"patternDateTime,omitempty"`
-	PatternDecimal                  *string                       `bson:"patternDecimal,omitempty" json:"patternDecimal,omitempty"`
+	PatternDecimal                  *float64                      `bson:"patternDecimal,omitempty" json:"patternDecimal,omitempty"`
 	PatternID                       *string                       `bson:"patternID,omitempty" json:"patternID,omitempty"`
 	PatternInstant                  *string                       `bson:"patternInstant,omitempty" json:"patternInstant,omitempty"`
 	PatternInteger                  *int                          `bson:"patternInteger,omitempty" json:"patternInteger,omitempty"`
@@ -196,7 +196,7 @@ type ElementDefinition struct {
 	MinValueDateTime                *string                       `bson:"minValueDateTime,omitempty" json:"minValueDateTime,omitempty"`
 	MinValueInstant                 *string                       `bson:"minValueInstant,omitempty" json:"minValueInstant,omitempty"`
 	MinValueTime                    *string                       `bson:"minValueTime,omitempty" json:"minValueTime,omitempty"`
-	MinValueDecimal                 *string                       `bson:"minValueDecimal,omitempty" json:"minValueDecimal,omitempty"`
+	MinValueDecimal                 *float64                      `bson:"minValueDecimal,omitempty" json:"minValueDecimal,omitempty"`
 	MinValueInteger                 *int                          `bson:"minValueInteger,omitempty" json:"minValueInteger,omitempty"`
 	MinValuePositiveInt             *int                          `bson:"minValuePositiveInt,omitempty" json:"minValuePositiveInt,omitempty"`
 	MinValueUnsignedInt             *int                          `bson:"minValueUnsignedInt,omitempty" json:"minValueUnsignedInt,omitempty"`
@@ -205,7 +205,7 @@ type ElementDefinition struct {
 	MaxValueDateTime                *string                       `bson:"maxValueDateTime,omitempty" json:"maxValueDateTime,omitempty"`
 	MaxValueInstant                 *string                       `bson:"maxValueInstant,omitempty" json:"maxValueInstant,omitempty"`
 	MaxValueTime                    *string                       `bson:"maxValueTime,omitempty" json:"maxValueTime,omitempty"`
-	MaxValueDecimal                 *string                       `bson:"maxValueDecimal,omitempty" json:"maxValueDecimal,omitempty"`
+	MaxValueDecimal                 *float64                      `bson:"maxValueDecimal,omitempty" json:"maxValueDecimal,omitempty"`
 	MaxValueInteger                 *int                          `bson:"maxValueInteger,omitempty" json:"maxValueInteger,omitempty"`
 	MaxValuePositiveInt             *int                          `bson:"maxValuePositiveInt,omitempty" json:"maxValuePositiveInt,omitempty"`
 	MaxValueUnsignedInt             *int                          `bson:"maxValueUnsignedInt,omitempty" json:"maxValueUnsignedInt,omitempty"`
@@ -260,7 +260,7 @@ type ElementDefinitionExample struct {
 	ValueCode                string              `bson:"valueCode" json:"valueCode"`
 	ValueDate                string              `bson:"valueDate" json:"valueDate"`
 	ValueDateTime            string              `bson:"valueDateTime" json:"valueDateTime"`
-	ValueDecimal             string              `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal             float64             `bson:"valueDecimal" json:"valueDecimal"`
 	ValueID                  string              `bson:"valueID" json:"valueID"`
 	ValueInstant             string              `bson:"valueInstant" json:"valueInstant"`
 	ValueInteger             int                 `bson:"valueInteger" json:"valueInteger"`

--- a/fhir-models-gen/fhir/extension.go
+++ b/fhir-models-gen/fhir/extension.go
@@ -28,7 +28,7 @@ type Extension struct {
 	ValueCode                *string              `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 	ValueDate                *string              `bson:"valueDate,omitempty" json:"valueDate,omitempty"`
 	ValueDateTime            *string              `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`
-	ValueDecimal             *string              `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueDecimal             *float64             `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueID                  *string              `bson:"valueID,omitempty" json:"valueID,omitempty"`
 	ValueInstant             *string              `bson:"valueInstant,omitempty" json:"valueInstant,omitempty"`
 	ValueInteger             *int                 `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`

--- a/fhir-models-gen/fhir/money.go
+++ b/fhir-models-gen/fhir/money.go
@@ -21,6 +21,6 @@ package fhir
 type Money struct {
 	ID        *string     `bson:"id,omitempty" json:"id,omitempty"`
 	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value     *string     `bson:"value,omitempty" json:"value,omitempty"`
+	Value     *float64    `bson:"value,omitempty" json:"value,omitempty"`
 	Currency  *string     `bson:"currency,omitempty" json:"currency,omitempty"`
 }

--- a/fhir-models-gen/fhir/quantity.go
+++ b/fhir-models-gen/fhir/quantity.go
@@ -21,7 +21,7 @@ package fhir
 type Quantity struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models-gen/fhir/sampledData.go
+++ b/fhir-models-gen/fhir/sampledData.go
@@ -22,10 +22,10 @@ type SampledData struct {
 	ID         *string     `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
 	Origin     Quantity    `bson:"origin" json:"origin"`
-	Period     string      `bson:"period" json:"period"`
-	Factor     *string     `bson:"factor,omitempty" json:"factor,omitempty"`
-	LowerLimit *string     `bson:"lowerLimit,omitempty" json:"lowerLimit,omitempty"`
-	UpperLimit *string     `bson:"upperLimit,omitempty" json:"upperLimit,omitempty"`
+	Period     float64     `bson:"period" json:"period"`
+	Factor     *float64    `bson:"factor,omitempty" json:"factor,omitempty"`
+	LowerLimit *float64    `bson:"lowerLimit,omitempty" json:"lowerLimit,omitempty"`
+	UpperLimit *float64    `bson:"upperLimit,omitempty" json:"upperLimit,omitempty"`
 	Dimensions int         `bson:"dimensions" json:"dimensions"`
 	Data       *string     `bson:"data,omitempty" json:"data,omitempty"`
 }

--- a/fhir-models-gen/fhir/timing.go
+++ b/fhir-models-gen/fhir/timing.go
@@ -34,13 +34,13 @@ type TimingRepeat struct {
 	BoundsPeriod   *Period      `bson:"boundsPeriod,omitempty" json:"boundsPeriod,omitempty"`
 	Count          *int         `bson:"count,omitempty" json:"count,omitempty"`
 	CountMax       *int         `bson:"countMax,omitempty" json:"countMax,omitempty"`
-	Duration       *string      `bson:"duration,omitempty" json:"duration,omitempty"`
-	DurationMax    *string      `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
+	Duration       *float64     `bson:"duration,omitempty" json:"duration,omitempty"`
+	DurationMax    *float64     `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
 	DurationUnit   *string      `bson:"durationUnit,omitempty" json:"durationUnit,omitempty"`
 	Frequency      *int         `bson:"frequency,omitempty" json:"frequency,omitempty"`
 	FrequencyMax   *int         `bson:"frequencyMax,omitempty" json:"frequencyMax,omitempty"`
-	Period         *string      `bson:"period,omitempty" json:"period,omitempty"`
-	PeriodMax      *string      `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
+	Period         *float64     `bson:"period,omitempty" json:"period,omitempty"`
+	PeriodMax      *float64     `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
 	PeriodUnit     *string      `bson:"periodUnit,omitempty" json:"periodUnit,omitempty"`
 	DayOfWeek      []DaysOfWeek `bson:"dayOfWeek,omitempty" json:"dayOfWeek,omitempty"`
 	TimeOfDay      []string     `bson:"timeOfDay,omitempty" json:"timeOfDay,omitempty"`

--- a/fhir-models-gen/fhir/valueSet.go
+++ b/fhir-models-gen/fhir/valueSet.go
@@ -112,7 +112,7 @@ type ValueSetExpansionParameter struct {
 	ValueString       *string     `bson:"valueString,omitempty" json:"valueString,omitempty"`
 	ValueBoolean      *bool       `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
 	ValueInteger      *int        `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`
-	ValueDecimal      *string     `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueDecimal      *float64    `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueUri          *string     `bson:"valueUri,omitempty" json:"valueUri,omitempty"`
 	ValueCode         *string     `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 	ValueDateTime     *string     `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`

--- a/fhir-models/fhir/age.go
+++ b/fhir-models/fhir/age.go
@@ -21,7 +21,7 @@ package fhir
 type Age struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models/fhir/biologicallyDerivedProduct.go
+++ b/fhir-models/fhir/biologicallyDerivedProduct.go
@@ -75,7 +75,7 @@ type BiologicallyDerivedProductStorage struct {
 	Extension         []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Description       *string                                 `bson:"description,omitempty" json:"description,omitempty"`
-	Temperature       *string                                 `bson:"temperature,omitempty" json:"temperature,omitempty"`
+	Temperature       *float64                                `bson:"temperature,omitempty" json:"temperature,omitempty"`
 	Scale             *BiologicallyDerivedProductStorageScale `bson:"scale,omitempty" json:"scale,omitempty"`
 	Duration          *Period                                 `bson:"duration,omitempty" json:"duration,omitempty"`
 }

--- a/fhir-models/fhir/bundle.go
+++ b/fhir-models/fhir/bundle.go
@@ -59,7 +59,7 @@ type BundleEntrySearch struct {
 	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Mode              *SearchEntryMode `bson:"mode,omitempty" json:"mode,omitempty"`
-	Score             *string          `bson:"score,omitempty" json:"score,omitempty"`
+	Score             *float64         `bson:"score,omitempty" json:"score,omitempty"`
 }
 type BundleEntryRequest struct {
 	ID                *string     `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models/fhir/chargeItem.go
+++ b/fhir-models/fhir/chargeItem.go
@@ -48,7 +48,7 @@ type ChargeItem struct {
 	CostCenter             *Reference            `bson:"costCenter,omitempty" json:"costCenter,omitempty"`
 	Quantity               *Quantity             `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	Bodysite               []CodeableConcept     `bson:"bodysite,omitempty" json:"bodysite,omitempty"`
-	FactorOverride         *string               `bson:"factorOverride,omitempty" json:"factorOverride,omitempty"`
+	FactorOverride         *float64              `bson:"factorOverride,omitempty" json:"factorOverride,omitempty"`
 	PriceOverride          *Money                `bson:"priceOverride,omitempty" json:"priceOverride,omitempty"`
 	OverrideReason         *string               `bson:"overrideReason,omitempty" json:"overrideReason,omitempty"`
 	Enterer                *Reference            `bson:"enterer,omitempty" json:"enterer,omitempty"`

--- a/fhir-models/fhir/chargeItemDefinition.go
+++ b/fhir-models/fhir/chargeItemDefinition.go
@@ -76,7 +76,7 @@ type ChargeItemDefinitionPropertyGroupPriceComponent struct {
 	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Type              InvoicePriceComponentType `bson:"type" json:"type"`
 	Code              *CodeableConcept          `bson:"code,omitempty" json:"code,omitempty"`
-	Factor            *string                   `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                  `bson:"factor,omitempty" json:"factor,omitempty"`
 	Amount            *Money                    `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type OtherChargeItemDefinition ChargeItemDefinition

--- a/fhir-models/fhir/claim.go
+++ b/fhir-models/fhir/claim.go
@@ -164,7 +164,7 @@ type ClaimItem struct {
 	LocationReference       *Reference        `bson:"locationReference,omitempty" json:"locationReference,omitempty"`
 	Quantity                *Quantity         `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice               *Money            `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor                  *string           `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor                  *float64          `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net                     *Money            `bson:"net,omitempty" json:"net,omitempty"`
 	Udi                     []Reference       `bson:"udi,omitempty" json:"udi,omitempty"`
 	BodySite                *CodeableConcept  `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
@@ -184,7 +184,7 @@ type ClaimItemDetail struct {
 	ProgramCode       []CodeableConcept          `bson:"programCode,omitempty" json:"programCode,omitempty"`
 	Quantity          *Quantity                  `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                     `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                    `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                   `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                     `bson:"net,omitempty" json:"net,omitempty"`
 	Udi               []Reference                `bson:"udi,omitempty" json:"udi,omitempty"`
 	SubDetail         []ClaimItemDetailSubDetail `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
@@ -201,7 +201,7 @@ type ClaimItemDetailSubDetail struct {
 	ProgramCode       []CodeableConcept `bson:"programCode,omitempty" json:"programCode,omitempty"`
 	Quantity          *Quantity         `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money            `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string           `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64          `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money            `bson:"net,omitempty" json:"net,omitempty"`
 	Udi               []Reference       `bson:"udi,omitempty" json:"udi,omitempty"`
 }

--- a/fhir-models/fhir/claimResponse.go
+++ b/fhir-models/fhir/claimResponse.go
@@ -75,7 +75,7 @@ type ClaimResponseItemAdjudication struct {
 	Category          CodeableConcept  `bson:"category" json:"category"`
 	Reason            *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 	Amount            *Money           `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value             *string          `bson:"value,omitempty" json:"value,omitempty"`
+	Value             *float64         `bson:"value,omitempty" json:"value,omitempty"`
 }
 type ClaimResponseItemDetail struct {
 	ID                *string                            `bson:"id,omitempty" json:"id,omitempty"`
@@ -112,7 +112,7 @@ type ClaimResponseAddItem struct {
 	LocationReference       *Reference                      `bson:"locationReference,omitempty" json:"locationReference,omitempty"`
 	Quantity                *Quantity                       `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice               *Money                          `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor                  *string                         `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor                  *float64                        `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net                     *Money                          `bson:"net,omitempty" json:"net,omitempty"`
 	BodySite                *CodeableConcept                `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
 	SubSite                 []CodeableConcept               `bson:"subSite,omitempty" json:"subSite,omitempty"`
@@ -128,7 +128,7 @@ type ClaimResponseAddItemDetail struct {
 	Modifier          []CodeableConcept                     `bson:"modifier,omitempty" json:"modifier,omitempty"`
 	Quantity          *Quantity                             `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                                `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                               `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                              `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                                `bson:"net,omitempty" json:"net,omitempty"`
 	NoteNumber        []int                                 `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
 	Adjudication      []ClaimResponseItemAdjudication       `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
@@ -142,7 +142,7 @@ type ClaimResponseAddItemDetailSubDetail struct {
 	Modifier          []CodeableConcept               `bson:"modifier,omitempty" json:"modifier,omitempty"`
 	Quantity          *Quantity                       `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                          `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                         `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                        `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                          `bson:"net,omitempty" json:"net,omitempty"`
 	NoteNumber        []int                           `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
 	Adjudication      []ClaimResponseItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`

--- a/fhir-models/fhir/codeSystem.go
+++ b/fhir-models/fhir/codeSystem.go
@@ -106,7 +106,7 @@ type CodeSystemConceptProperty struct {
 	ValueInteger      int         `bson:"valueInteger" json:"valueInteger"`
 	ValueBoolean      bool        `bson:"valueBoolean" json:"valueBoolean"`
 	ValueDateTime     string      `bson:"valueDateTime" json:"valueDateTime"`
-	ValueDecimal      string      `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal      float64     `bson:"valueDecimal" json:"valueDecimal"`
 }
 type OtherCodeSystem CodeSystem
 

--- a/fhir-models/fhir/contract.go
+++ b/fhir-models/fhir/contract.go
@@ -132,7 +132,7 @@ type ContractTermOfferAnswer struct {
 	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	ValueBoolean      bool        `bson:"valueBoolean" json:"valueBoolean"`
-	ValueDecimal      string      `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal      float64     `bson:"valueDecimal" json:"valueDecimal"`
 	ValueInteger      int         `bson:"valueInteger" json:"valueInteger"`
 	ValueDate         string      `bson:"valueDate" json:"valueDate"`
 	ValueDateTime     string      `bson:"valueDateTime" json:"valueDateTime"`
@@ -182,8 +182,8 @@ type ContractTermAssetValuedItem struct {
 	EffectiveTime         *string          `bson:"effectiveTime,omitempty" json:"effectiveTime,omitempty"`
 	Quantity              *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice             *Money           `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor                *string          `bson:"factor,omitempty" json:"factor,omitempty"`
-	Points                *string          `bson:"points,omitempty" json:"points,omitempty"`
+	Factor                *float64         `bson:"factor,omitempty" json:"factor,omitempty"`
+	Points                *float64         `bson:"points,omitempty" json:"points,omitempty"`
 	Net                   *Money           `bson:"net,omitempty" json:"net,omitempty"`
 	Payment               *string          `bson:"payment,omitempty" json:"payment,omitempty"`
 	PaymentDate           *string          `bson:"paymentDate,omitempty" json:"paymentDate,omitempty"`

--- a/fhir-models/fhir/count.go
+++ b/fhir-models/fhir/count.go
@@ -21,7 +21,7 @@ package fhir
 type Count struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models/fhir/distance.go
+++ b/fhir-models/fhir/distance.go
@@ -21,7 +21,7 @@ package fhir
 type Distance struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models/fhir/duration.go
+++ b/fhir-models/fhir/duration.go
@@ -21,7 +21,7 @@ package fhir
 type Duration struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models/fhir/effectEvidenceSynthesis.go
+++ b/fhir-models/fhir/effectEvidenceSynthesis.go
@@ -89,7 +89,7 @@ type EffectEvidenceSynthesisEffectEstimate struct {
 	Description       *string                                                  `bson:"description,omitempty" json:"description,omitempty"`
 	Type              *CodeableConcept                                         `bson:"type,omitempty" json:"type,omitempty"`
 	VariantState      *CodeableConcept                                         `bson:"variantState,omitempty" json:"variantState,omitempty"`
-	Value             *string                                                  `bson:"value,omitempty" json:"value,omitempty"`
+	Value             *float64                                                 `bson:"value,omitempty" json:"value,omitempty"`
 	UnitOfMeasure     *CodeableConcept                                         `bson:"unitOfMeasure,omitempty" json:"unitOfMeasure,omitempty"`
 	PrecisionEstimate []EffectEvidenceSynthesisEffectEstimatePrecisionEstimate `bson:"precisionEstimate,omitempty" json:"precisionEstimate,omitempty"`
 }
@@ -98,9 +98,9 @@ type EffectEvidenceSynthesisEffectEstimatePrecisionEstimate struct {
 	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Level             *string          `bson:"level,omitempty" json:"level,omitempty"`
-	From              *string          `bson:"from,omitempty" json:"from,omitempty"`
-	To                *string          `bson:"to,omitempty" json:"to,omitempty"`
+	Level             *float64         `bson:"level,omitempty" json:"level,omitempty"`
+	From              *float64         `bson:"from,omitempty" json:"from,omitempty"`
+	To                *float64         `bson:"to,omitempty" json:"to,omitempty"`
 }
 type EffectEvidenceSynthesisCertainty struct {
 	ID                    *string                                                 `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models/fhir/elementDefinition.go
+++ b/fhir-models/fhir/elementDefinition.go
@@ -45,7 +45,7 @@ type ElementDefinition struct {
 	DefaultValueCode                *string                       `bson:"defaultValueCode,omitempty" json:"defaultValueCode,omitempty"`
 	DefaultValueDate                *string                       `bson:"defaultValueDate,omitempty" json:"defaultValueDate,omitempty"`
 	DefaultValueDateTime            *string                       `bson:"defaultValueDateTime,omitempty" json:"defaultValueDateTime,omitempty"`
-	DefaultValueDecimal             *string                       `bson:"defaultValueDecimal,omitempty" json:"defaultValueDecimal,omitempty"`
+	DefaultValueDecimal             *float64                      `bson:"defaultValueDecimal,omitempty" json:"defaultValueDecimal,omitempty"`
 	DefaultValueID                  *string                       `bson:"defaultValueID,omitempty" json:"defaultValueID,omitempty"`
 	DefaultValueInstant             *string                       `bson:"defaultValueInstant,omitempty" json:"defaultValueInstant,omitempty"`
 	DefaultValueInteger             *int                          `bson:"defaultValueInteger,omitempty" json:"defaultValueInteger,omitempty"`
@@ -97,7 +97,7 @@ type ElementDefinition struct {
 	FixedCode                       *string                       `bson:"fixedCode,omitempty" json:"fixedCode,omitempty"`
 	FixedDate                       *string                       `bson:"fixedDate,omitempty" json:"fixedDate,omitempty"`
 	FixedDateTime                   *string                       `bson:"fixedDateTime,omitempty" json:"fixedDateTime,omitempty"`
-	FixedDecimal                    *string                       `bson:"fixedDecimal,omitempty" json:"fixedDecimal,omitempty"`
+	FixedDecimal                    *float64                      `bson:"fixedDecimal,omitempty" json:"fixedDecimal,omitempty"`
 	FixedID                         *string                       `bson:"fixedID,omitempty" json:"fixedID,omitempty"`
 	FixedInstant                    *string                       `bson:"fixedInstant,omitempty" json:"fixedInstant,omitempty"`
 	FixedInteger                    *int                          `bson:"fixedInteger,omitempty" json:"fixedInteger,omitempty"`
@@ -147,7 +147,7 @@ type ElementDefinition struct {
 	PatternCode                     *string                       `bson:"patternCode,omitempty" json:"patternCode,omitempty"`
 	PatternDate                     *string                       `bson:"patternDate,omitempty" json:"patternDate,omitempty"`
 	PatternDateTime                 *string                       `bson:"patternDateTime,omitempty" json:"patternDateTime,omitempty"`
-	PatternDecimal                  *string                       `bson:"patternDecimal,omitempty" json:"patternDecimal,omitempty"`
+	PatternDecimal                  *float64                      `bson:"patternDecimal,omitempty" json:"patternDecimal,omitempty"`
 	PatternID                       *string                       `bson:"patternID,omitempty" json:"patternID,omitempty"`
 	PatternInstant                  *string                       `bson:"patternInstant,omitempty" json:"patternInstant,omitempty"`
 	PatternInteger                  *int                          `bson:"patternInteger,omitempty" json:"patternInteger,omitempty"`
@@ -196,7 +196,7 @@ type ElementDefinition struct {
 	MinValueDateTime                *string                       `bson:"minValueDateTime,omitempty" json:"minValueDateTime,omitempty"`
 	MinValueInstant                 *string                       `bson:"minValueInstant,omitempty" json:"minValueInstant,omitempty"`
 	MinValueTime                    *string                       `bson:"minValueTime,omitempty" json:"minValueTime,omitempty"`
-	MinValueDecimal                 *string                       `bson:"minValueDecimal,omitempty" json:"minValueDecimal,omitempty"`
+	MinValueDecimal                 *float64                      `bson:"minValueDecimal,omitempty" json:"minValueDecimal,omitempty"`
 	MinValueInteger                 *int                          `bson:"minValueInteger,omitempty" json:"minValueInteger,omitempty"`
 	MinValuePositiveInt             *int                          `bson:"minValuePositiveInt,omitempty" json:"minValuePositiveInt,omitempty"`
 	MinValueUnsignedInt             *int                          `bson:"minValueUnsignedInt,omitempty" json:"minValueUnsignedInt,omitempty"`
@@ -205,7 +205,7 @@ type ElementDefinition struct {
 	MaxValueDateTime                *string                       `bson:"maxValueDateTime,omitempty" json:"maxValueDateTime,omitempty"`
 	MaxValueInstant                 *string                       `bson:"maxValueInstant,omitempty" json:"maxValueInstant,omitempty"`
 	MaxValueTime                    *string                       `bson:"maxValueTime,omitempty" json:"maxValueTime,omitempty"`
-	MaxValueDecimal                 *string                       `bson:"maxValueDecimal,omitempty" json:"maxValueDecimal,omitempty"`
+	MaxValueDecimal                 *float64                      `bson:"maxValueDecimal,omitempty" json:"maxValueDecimal,omitempty"`
 	MaxValueInteger                 *int                          `bson:"maxValueInteger,omitempty" json:"maxValueInteger,omitempty"`
 	MaxValuePositiveInt             *int                          `bson:"maxValuePositiveInt,omitempty" json:"maxValuePositiveInt,omitempty"`
 	MaxValueUnsignedInt             *int                          `bson:"maxValueUnsignedInt,omitempty" json:"maxValueUnsignedInt,omitempty"`
@@ -260,7 +260,7 @@ type ElementDefinitionExample struct {
 	ValueCode                string              `bson:"valueCode" json:"valueCode"`
 	ValueDate                string              `bson:"valueDate" json:"valueDate"`
 	ValueDateTime            string              `bson:"valueDateTime" json:"valueDateTime"`
-	ValueDecimal             string              `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal             float64             `bson:"valueDecimal" json:"valueDecimal"`
 	ValueID                  string              `bson:"valueID" json:"valueID"`
 	ValueInstant             string              `bson:"valueInstant" json:"valueInstant"`
 	ValueInteger             int                 `bson:"valueInteger" json:"valueInteger"`

--- a/fhir-models/fhir/explanationOfBenefit.go
+++ b/fhir-models/fhir/explanationOfBenefit.go
@@ -176,7 +176,7 @@ type ExplanationOfBenefitItem struct {
 	LocationReference       *Reference                             `bson:"locationReference,omitempty" json:"locationReference,omitempty"`
 	Quantity                *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice               *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor                  *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor                  *float64                               `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net                     *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
 	Udi                     []Reference                            `bson:"udi,omitempty" json:"udi,omitempty"`
 	BodySite                *CodeableConcept                       `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
@@ -193,7 +193,7 @@ type ExplanationOfBenefitItemAdjudication struct {
 	Category          CodeableConcept  `bson:"category" json:"category"`
 	Reason            *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 	Amount            *Money           `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value             *string          `bson:"value,omitempty" json:"value,omitempty"`
+	Value             *float64         `bson:"value,omitempty" json:"value,omitempty"`
 }
 type ExplanationOfBenefitItemDetail struct {
 	ID                *string                                   `bson:"id,omitempty" json:"id,omitempty"`
@@ -207,7 +207,7 @@ type ExplanationOfBenefitItemDetail struct {
 	ProgramCode       []CodeableConcept                         `bson:"programCode,omitempty" json:"programCode,omitempty"`
 	Quantity          *Quantity                                 `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                                    `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                                   `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                                  `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                                    `bson:"net,omitempty" json:"net,omitempty"`
 	Udi               []Reference                               `bson:"udi,omitempty" json:"udi,omitempty"`
 	NoteNumber        []int                                     `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
@@ -226,7 +226,7 @@ type ExplanationOfBenefitItemDetailSubDetail struct {
 	ProgramCode       []CodeableConcept                      `bson:"programCode,omitempty" json:"programCode,omitempty"`
 	Quantity          *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                               `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
 	Udi               []Reference                            `bson:"udi,omitempty" json:"udi,omitempty"`
 	NoteNumber        []int                                  `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
@@ -250,7 +250,7 @@ type ExplanationOfBenefitAddItem struct {
 	LocationReference       *Reference                             `bson:"locationReference,omitempty" json:"locationReference,omitempty"`
 	Quantity                *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice               *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor                  *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor                  *float64                               `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net                     *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
 	BodySite                *CodeableConcept                       `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
 	SubSite                 []CodeableConcept                      `bson:"subSite,omitempty" json:"subSite,omitempty"`
@@ -266,7 +266,7 @@ type ExplanationOfBenefitAddItemDetail struct {
 	Modifier          []CodeableConcept                            `bson:"modifier,omitempty" json:"modifier,omitempty"`
 	Quantity          *Quantity                                    `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                                       `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                                      `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                                     `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                                       `bson:"net,omitempty" json:"net,omitempty"`
 	NoteNumber        []int                                        `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
 	Adjudication      []ExplanationOfBenefitItemAdjudication       `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
@@ -280,7 +280,7 @@ type ExplanationOfBenefitAddItemDetailSubDetail struct {
 	Modifier          []CodeableConcept                      `bson:"modifier,omitempty" json:"modifier,omitempty"`
 	Quantity          *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	UnitPrice         *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor            *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                               `bson:"factor,omitempty" json:"factor,omitempty"`
 	Net               *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
 	NoteNumber        []int                                  `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
 	Adjudication      []ExplanationOfBenefitItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`

--- a/fhir-models/fhir/extension.go
+++ b/fhir-models/fhir/extension.go
@@ -28,7 +28,7 @@ type Extension struct {
 	ValueCode                *string              `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 	ValueDate                *string              `bson:"valueDate,omitempty" json:"valueDate,omitempty"`
 	ValueDateTime            *string              `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`
-	ValueDecimal             *string              `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueDecimal             *float64             `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueID                  *string              `bson:"valueID,omitempty" json:"valueID,omitempty"`
 	ValueInstant             *string              `bson:"valueInstant,omitempty" json:"valueInstant,omitempty"`
 	ValueInteger             *int                 `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`

--- a/fhir-models/fhir/invoice.go
+++ b/fhir-models/fhir/invoice.go
@@ -70,7 +70,7 @@ type InvoiceLineItemPriceComponent struct {
 	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Type              InvoicePriceComponentType `bson:"type" json:"type"`
 	Code              *CodeableConcept          `bson:"code,omitempty" json:"code,omitempty"`
-	Factor            *string                   `bson:"factor,omitempty" json:"factor,omitempty"`
+	Factor            *float64                  `bson:"factor,omitempty" json:"factor,omitempty"`
 	Amount            *Money                    `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type OtherInvoice Invoice

--- a/fhir-models/fhir/location.go
+++ b/fhir-models/fhir/location.go
@@ -53,9 +53,9 @@ type LocationPosition struct {
 	ID                *string     `bson:"id,omitempty" json:"id,omitempty"`
 	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
-	Longitude         string      `bson:"longitude" json:"longitude"`
-	Latitude          string      `bson:"latitude" json:"latitude"`
-	Altitude          *string     `bson:"altitude,omitempty" json:"altitude,omitempty"`
+	Longitude         float64     `bson:"longitude" json:"longitude"`
+	Latitude          float64     `bson:"latitude" json:"latitude"`
+	Altitude          *float64    `bson:"altitude,omitempty" json:"altitude,omitempty"`
 }
 type LocationHoursOfOperation struct {
 	ID                *string      `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models/fhir/media.go
+++ b/fhir-models/fhir/media.go
@@ -51,7 +51,7 @@ type Media struct {
 	Height            *int              `bson:"height,omitempty" json:"height,omitempty"`
 	Width             *int              `bson:"width,omitempty" json:"width,omitempty"`
 	Frames            *int              `bson:"frames,omitempty" json:"frames,omitempty"`
-	Duration          *string           `bson:"duration,omitempty" json:"duration,omitempty"`
+	Duration          *float64          `bson:"duration,omitempty" json:"duration,omitempty"`
 	Content           Attachment        `bson:"content" json:"content"`
 	Note              []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
 }

--- a/fhir-models/fhir/molecularSequence.go
+++ b/fhir-models/fhir/molecularSequence.go
@@ -83,14 +83,14 @@ type MolecularSequenceQuality struct {
 	End               *int                         `bson:"end,omitempty" json:"end,omitempty"`
 	Score             *Quantity                    `bson:"score,omitempty" json:"score,omitempty"`
 	Method            *CodeableConcept             `bson:"method,omitempty" json:"method,omitempty"`
-	TruthTP           *string                      `bson:"truthTP,omitempty" json:"truthTP,omitempty"`
-	QueryTP           *string                      `bson:"queryTP,omitempty" json:"queryTP,omitempty"`
-	TruthFN           *string                      `bson:"truthFN,omitempty" json:"truthFN,omitempty"`
-	QueryFP           *string                      `bson:"queryFP,omitempty" json:"queryFP,omitempty"`
-	GtFP              *string                      `bson:"gtFP,omitempty" json:"gtFP,omitempty"`
-	Precision         *string                      `bson:"precision,omitempty" json:"precision,omitempty"`
-	Recall            *string                      `bson:"recall,omitempty" json:"recall,omitempty"`
-	FScore            *string                      `bson:"fScore,omitempty" json:"fScore,omitempty"`
+	TruthTP           *float64                     `bson:"truthTP,omitempty" json:"truthTP,omitempty"`
+	QueryTP           *float64                     `bson:"queryTP,omitempty" json:"queryTP,omitempty"`
+	TruthFN           *float64                     `bson:"truthFN,omitempty" json:"truthFN,omitempty"`
+	QueryFP           *float64                     `bson:"queryFP,omitempty" json:"queryFP,omitempty"`
+	GtFP              *float64                     `bson:"gtFP,omitempty" json:"gtFP,omitempty"`
+	Precision         *float64                     `bson:"precision,omitempty" json:"precision,omitempty"`
+	Recall            *float64                     `bson:"recall,omitempty" json:"recall,omitempty"`
+	FScore            *float64                     `bson:"fScore,omitempty" json:"fScore,omitempty"`
 	Roc               *MolecularSequenceQualityRoc `bson:"roc,omitempty" json:"roc,omitempty"`
 }
 type MolecularSequenceQualityRoc struct {
@@ -101,9 +101,9 @@ type MolecularSequenceQualityRoc struct {
 	NumTP             []int       `bson:"numTP,omitempty" json:"numTP,omitempty"`
 	NumFP             []int       `bson:"numFP,omitempty" json:"numFP,omitempty"`
 	NumFN             []int       `bson:"numFN,omitempty" json:"numFN,omitempty"`
-	Precision         []string    `bson:"precision,omitempty" json:"precision,omitempty"`
-	Sensitivity       []string    `bson:"sensitivity,omitempty" json:"sensitivity,omitempty"`
-	FMeasure          []string    `bson:"fMeasure,omitempty" json:"fMeasure,omitempty"`
+	Precision         []float64   `bson:"precision,omitempty" json:"precision,omitempty"`
+	Sensitivity       []float64   `bson:"sensitivity,omitempty" json:"sensitivity,omitempty"`
+	FMeasure          []float64   `bson:"fMeasure,omitempty" json:"fMeasure,omitempty"`
 }
 type MolecularSequenceRepository struct {
 	ID                *string     `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models/fhir/money.go
+++ b/fhir-models/fhir/money.go
@@ -21,6 +21,6 @@ package fhir
 type Money struct {
 	ID        *string     `bson:"id,omitempty" json:"id,omitempty"`
 	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value     *string     `bson:"value,omitempty" json:"value,omitempty"`
+	Value     *float64    `bson:"value,omitempty" json:"value,omitempty"`
 	Currency  *string     `bson:"currency,omitempty" json:"currency,omitempty"`
 }

--- a/fhir-models/fhir/observationDefinition.go
+++ b/fhir-models/fhir/observationDefinition.go
@@ -51,7 +51,7 @@ type ObservationDefinitionQuantitativeDetails struct {
 	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	CustomaryUnit     *CodeableConcept `bson:"customaryUnit,omitempty" json:"customaryUnit,omitempty"`
 	Unit              *CodeableConcept `bson:"unit,omitempty" json:"unit,omitempty"`
-	ConversionFactor  *string          `bson:"conversionFactor,omitempty" json:"conversionFactor,omitempty"`
+	ConversionFactor  *float64         `bson:"conversionFactor,omitempty" json:"conversionFactor,omitempty"`
 	DecimalPrecision  *int             `bson:"decimalPrecision,omitempty" json:"decimalPrecision,omitempty"`
 }
 type ObservationDefinitionQualifiedInterval struct {

--- a/fhir-models/fhir/parameters.go
+++ b/fhir-models/fhir/parameters.go
@@ -41,7 +41,7 @@ type ParametersParameter struct {
 	ValueCode                *string               `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 	ValueDate                *string               `bson:"valueDate,omitempty" json:"valueDate,omitempty"`
 	ValueDateTime            *string               `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`
-	ValueDecimal             *string               `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueDecimal             *float64              `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueID                  *string               `bson:"valueID,omitempty" json:"valueID,omitempty"`
 	ValueInstant             *string               `bson:"valueInstant,omitempty" json:"valueInstant,omitempty"`
 	ValueInteger             *int                  `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`

--- a/fhir-models/fhir/quantity.go
+++ b/fhir-models/fhir/quantity.go
@@ -21,7 +21,7 @@ package fhir
 type Quantity struct {
 	ID         *string             `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
-	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Value      *float64            `bson:"value,omitempty" json:"value,omitempty"`
 	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
 	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
 	System     *string             `bson:"system,omitempty" json:"system,omitempty"`

--- a/fhir-models/fhir/questionnaire.go
+++ b/fhir-models/fhir/questionnaire.go
@@ -82,7 +82,7 @@ type QuestionnaireItemEnableWhen struct {
 	Question          string                    `bson:"question" json:"question"`
 	Operator          QuestionnaireItemOperator `bson:"operator" json:"operator"`
 	AnswerBoolean     bool                      `bson:"answerBoolean" json:"answerBoolean"`
-	AnswerDecimal     string                    `bson:"answerDecimal" json:"answerDecimal"`
+	AnswerDecimal     float64                   `bson:"answerDecimal" json:"answerDecimal"`
 	AnswerInteger     int                       `bson:"answerInteger" json:"answerInteger"`
 	AnswerDate        string                    `bson:"answerDate" json:"answerDate"`
 	AnswerDateTime    string                    `bson:"answerDateTime" json:"answerDateTime"`
@@ -109,7 +109,7 @@ type QuestionnaireItemInitial struct {
 	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	ValueBoolean      bool        `bson:"valueBoolean" json:"valueBoolean"`
-	ValueDecimal      string      `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal      float64     `bson:"valueDecimal" json:"valueDecimal"`
 	ValueInteger      int         `bson:"valueInteger" json:"valueInteger"`
 	ValueDate         string      `bson:"valueDate" json:"valueDate"`
 	ValueDateTime     string      `bson:"valueDateTime" json:"valueDateTime"`

--- a/fhir-models/fhir/questionnaireResponse.go
+++ b/fhir-models/fhir/questionnaireResponse.go
@@ -58,7 +58,7 @@ type QuestionnaireResponseItemAnswer struct {
 	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	ValueBoolean      *bool                       `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
-	ValueDecimal      *string                     `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueDecimal      *float64                    `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueInteger      *int                        `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`
 	ValueDate         *string                     `bson:"valueDate,omitempty" json:"valueDate,omitempty"`
 	ValueDateTime     *string                     `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`

--- a/fhir-models/fhir/riskAssessment.go
+++ b/fhir-models/fhir/riskAssessment.go
@@ -55,10 +55,10 @@ type RiskAssessmentPrediction struct {
 	Extension          []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension  []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Outcome            *CodeableConcept `bson:"outcome,omitempty" json:"outcome,omitempty"`
-	ProbabilityDecimal *string          `bson:"probabilityDecimal,omitempty" json:"probabilityDecimal,omitempty"`
+	ProbabilityDecimal *float64         `bson:"probabilityDecimal,omitempty" json:"probabilityDecimal,omitempty"`
 	ProbabilityRange   *Range           `bson:"probabilityRange,omitempty" json:"probabilityRange,omitempty"`
 	QualitativeRisk    *CodeableConcept `bson:"qualitativeRisk,omitempty" json:"qualitativeRisk,omitempty"`
-	RelativeRisk       *string          `bson:"relativeRisk,omitempty" json:"relativeRisk,omitempty"`
+	RelativeRisk       *float64         `bson:"relativeRisk,omitempty" json:"relativeRisk,omitempty"`
 	WhenPeriod         *Period          `bson:"whenPeriod,omitempty" json:"whenPeriod,omitempty"`
 	WhenRange          *Range           `bson:"whenRange,omitempty" json:"whenRange,omitempty"`
 	Rationale          *string          `bson:"rationale,omitempty" json:"rationale,omitempty"`

--- a/fhir-models/fhir/riskEvidenceSynthesis.go
+++ b/fhir-models/fhir/riskEvidenceSynthesis.go
@@ -77,7 +77,7 @@ type RiskEvidenceSynthesisRiskEstimate struct {
 	ModifierExtension []Extension                                          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Description       *string                                              `bson:"description,omitempty" json:"description,omitempty"`
 	Type              *CodeableConcept                                     `bson:"type,omitempty" json:"type,omitempty"`
-	Value             *string                                              `bson:"value,omitempty" json:"value,omitempty"`
+	Value             *float64                                             `bson:"value,omitempty" json:"value,omitempty"`
 	UnitOfMeasure     *CodeableConcept                                     `bson:"unitOfMeasure,omitempty" json:"unitOfMeasure,omitempty"`
 	DenominatorCount  *int                                                 `bson:"denominatorCount,omitempty" json:"denominatorCount,omitempty"`
 	NumeratorCount    *int                                                 `bson:"numeratorCount,omitempty" json:"numeratorCount,omitempty"`
@@ -88,9 +88,9 @@ type RiskEvidenceSynthesisRiskEstimatePrecisionEstimate struct {
 	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Level             *string          `bson:"level,omitempty" json:"level,omitempty"`
-	From              *string          `bson:"from,omitempty" json:"from,omitempty"`
-	To                *string          `bson:"to,omitempty" json:"to,omitempty"`
+	Level             *float64         `bson:"level,omitempty" json:"level,omitempty"`
+	From              *float64         `bson:"from,omitempty" json:"from,omitempty"`
+	To                *float64         `bson:"to,omitempty" json:"to,omitempty"`
 }
 type RiskEvidenceSynthesisCertainty struct {
 	ID                    *string                                               `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models/fhir/sampledData.go
+++ b/fhir-models/fhir/sampledData.go
@@ -22,10 +22,10 @@ type SampledData struct {
 	ID         *string     `bson:"id,omitempty" json:"id,omitempty"`
 	Extension  []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
 	Origin     Quantity    `bson:"origin" json:"origin"`
-	Period     string      `bson:"period" json:"period"`
-	Factor     *string     `bson:"factor,omitempty" json:"factor,omitempty"`
-	LowerLimit *string     `bson:"lowerLimit,omitempty" json:"lowerLimit,omitempty"`
-	UpperLimit *string     `bson:"upperLimit,omitempty" json:"upperLimit,omitempty"`
+	Period     float64     `bson:"period" json:"period"`
+	Factor     *float64    `bson:"factor,omitempty" json:"factor,omitempty"`
+	LowerLimit *float64    `bson:"lowerLimit,omitempty" json:"lowerLimit,omitempty"`
+	UpperLimit *float64    `bson:"upperLimit,omitempty" json:"upperLimit,omitempty"`
 	Dimensions int         `bson:"dimensions" json:"dimensions"`
 	Data       *string     `bson:"data,omitempty" json:"data,omitempty"`
 }

--- a/fhir-models/fhir/structureMap.go
+++ b/fhir-models/fhir/structureMap.go
@@ -104,7 +104,7 @@ type StructureMapGroupRuleSource struct {
 	DefaultValueCode                *string                     `bson:"defaultValueCode,omitempty" json:"defaultValueCode,omitempty"`
 	DefaultValueDate                *string                     `bson:"defaultValueDate,omitempty" json:"defaultValueDate,omitempty"`
 	DefaultValueDateTime            *string                     `bson:"defaultValueDateTime,omitempty" json:"defaultValueDateTime,omitempty"`
-	DefaultValueDecimal             *string                     `bson:"defaultValueDecimal,omitempty" json:"defaultValueDecimal,omitempty"`
+	DefaultValueDecimal             *float64                    `bson:"defaultValueDecimal,omitempty" json:"defaultValueDecimal,omitempty"`
 	DefaultValueID                  *string                     `bson:"defaultValueID,omitempty" json:"defaultValueID,omitempty"`
 	DefaultValueInstant             *string                     `bson:"defaultValueInstant,omitempty" json:"defaultValueInstant,omitempty"`
 	DefaultValueInteger             *int                        `bson:"defaultValueInteger,omitempty" json:"defaultValueInteger,omitempty"`
@@ -176,7 +176,7 @@ type StructureMapGroupRuleTargetParameter struct {
 	ValueString       string      `bson:"valueString" json:"valueString"`
 	ValueBoolean      bool        `bson:"valueBoolean" json:"valueBoolean"`
 	ValueInteger      int         `bson:"valueInteger" json:"valueInteger"`
-	ValueDecimal      string      `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal      float64     `bson:"valueDecimal" json:"valueDecimal"`
 }
 type StructureMapGroupRuleDependent struct {
 	ID                *string     `bson:"id,omitempty" json:"id,omitempty"`

--- a/fhir-models/fhir/task.go
+++ b/fhir-models/fhir/task.go
@@ -82,7 +82,7 @@ type TaskInput struct {
 	ValueCode                string              `bson:"valueCode" json:"valueCode"`
 	ValueDate                string              `bson:"valueDate" json:"valueDate"`
 	ValueDateTime            string              `bson:"valueDateTime" json:"valueDateTime"`
-	ValueDecimal             string              `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal             float64             `bson:"valueDecimal" json:"valueDecimal"`
 	ValueID                  string              `bson:"valueID" json:"valueID"`
 	ValueInstant             string              `bson:"valueInstant" json:"valueInstant"`
 	ValueInteger             int                 `bson:"valueInteger" json:"valueInteger"`
@@ -138,7 +138,7 @@ type TaskOutput struct {
 	ValueCode                string              `bson:"valueCode" json:"valueCode"`
 	ValueDate                string              `bson:"valueDate" json:"valueDate"`
 	ValueDateTime            string              `bson:"valueDateTime" json:"valueDateTime"`
-	ValueDecimal             string              `bson:"valueDecimal" json:"valueDecimal"`
+	ValueDecimal             float64             `bson:"valueDecimal" json:"valueDecimal"`
 	ValueID                  string              `bson:"valueID" json:"valueID"`
 	ValueInstant             string              `bson:"valueInstant" json:"valueInstant"`
 	ValueInteger             int                 `bson:"valueInteger" json:"valueInteger"`

--- a/fhir-models/fhir/testReport.go
+++ b/fhir-models/fhir/testReport.go
@@ -36,7 +36,7 @@ type TestReport struct {
 	Status            TestReportStatus        `bson:"status" json:"status"`
 	TestScript        Reference               `bson:"testScript" json:"testScript"`
 	Result            TestReportResult        `bson:"result" json:"result"`
-	Score             *string                 `bson:"score,omitempty" json:"score,omitempty"`
+	Score             *float64                `bson:"score,omitempty" json:"score,omitempty"`
 	Tester            *string                 `bson:"tester,omitempty" json:"tester,omitempty"`
 	Issued            *string                 `bson:"issued,omitempty" json:"issued,omitempty"`
 	Participant       []TestReportParticipant `bson:"participant,omitempty" json:"participant,omitempty"`

--- a/fhir-models/fhir/timing.go
+++ b/fhir-models/fhir/timing.go
@@ -34,13 +34,13 @@ type TimingRepeat struct {
 	BoundsPeriod   *Period      `bson:"boundsPeriod,omitempty" json:"boundsPeriod,omitempty"`
 	Count          *int         `bson:"count,omitempty" json:"count,omitempty"`
 	CountMax       *int         `bson:"countMax,omitempty" json:"countMax,omitempty"`
-	Duration       *string      `bson:"duration,omitempty" json:"duration,omitempty"`
-	DurationMax    *string      `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
+	Duration       *float64     `bson:"duration,omitempty" json:"duration,omitempty"`
+	DurationMax    *float64     `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
 	DurationUnit   *string      `bson:"durationUnit,omitempty" json:"durationUnit,omitempty"`
 	Frequency      *int         `bson:"frequency,omitempty" json:"frequency,omitempty"`
 	FrequencyMax   *int         `bson:"frequencyMax,omitempty" json:"frequencyMax,omitempty"`
-	Period         *string      `bson:"period,omitempty" json:"period,omitempty"`
-	PeriodMax      *string      `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
+	Period         *float64     `bson:"period,omitempty" json:"period,omitempty"`
+	PeriodMax      *float64     `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
 	PeriodUnit     *string      `bson:"periodUnit,omitempty" json:"periodUnit,omitempty"`
 	DayOfWeek      []DaysOfWeek `bson:"dayOfWeek,omitempty" json:"dayOfWeek,omitempty"`
 	TimeOfDay      []string     `bson:"timeOfDay,omitempty" json:"timeOfDay,omitempty"`

--- a/fhir-models/fhir/valueSet.go
+++ b/fhir-models/fhir/valueSet.go
@@ -112,7 +112,7 @@ type ValueSetExpansionParameter struct {
 	ValueString       *string     `bson:"valueString,omitempty" json:"valueString,omitempty"`
 	ValueBoolean      *bool       `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
 	ValueInteger      *int        `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`
-	ValueDecimal      *string     `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueDecimal      *float64    `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueUri          *string     `bson:"valueUri,omitempty" json:"valueUri,omitempty"`
 	ValueCode         *string     `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 	ValueDateTime     *string     `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`

--- a/fhir-models/fhir/visionPrescription.go
+++ b/fhir-models/fhir/visionPrescription.go
@@ -46,14 +46,14 @@ type VisionPrescriptionLensSpecification struct {
 	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 	Product           CodeableConcept                            `bson:"product" json:"product"`
 	Eye               VisionEyes                                 `bson:"eye" json:"eye"`
-	Sphere            *string                                    `bson:"sphere,omitempty" json:"sphere,omitempty"`
-	Cylinder          *string                                    `bson:"cylinder,omitempty" json:"cylinder,omitempty"`
+	Sphere            *float64                                   `bson:"sphere,omitempty" json:"sphere,omitempty"`
+	Cylinder          *float64                                   `bson:"cylinder,omitempty" json:"cylinder,omitempty"`
 	Axis              *int                                       `bson:"axis,omitempty" json:"axis,omitempty"`
 	Prism             []VisionPrescriptionLensSpecificationPrism `bson:"prism,omitempty" json:"prism,omitempty"`
-	Add               *string                                    `bson:"add,omitempty" json:"add,omitempty"`
-	Power             *string                                    `bson:"power,omitempty" json:"power,omitempty"`
-	BackCurve         *string                                    `bson:"backCurve,omitempty" json:"backCurve,omitempty"`
-	Diameter          *string                                    `bson:"diameter,omitempty" json:"diameter,omitempty"`
+	Add               *float64                                   `bson:"add,omitempty" json:"add,omitempty"`
+	Power             *float64                                   `bson:"power,omitempty" json:"power,omitempty"`
+	BackCurve         *float64                                   `bson:"backCurve,omitempty" json:"backCurve,omitempty"`
+	Diameter          *float64                                   `bson:"diameter,omitempty" json:"diameter,omitempty"`
 	Duration          *Quantity                                  `bson:"duration,omitempty" json:"duration,omitempty"`
 	Color             *string                                    `bson:"color,omitempty" json:"color,omitempty"`
 	Brand             *string                                    `bson:"brand,omitempty" json:"brand,omitempty"`
@@ -63,7 +63,7 @@ type VisionPrescriptionLensSpecificationPrism struct {
 	ID                *string     `bson:"id,omitempty" json:"id,omitempty"`
 	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
 	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
-	Amount            string      `bson:"amount" json:"amount"`
+	Amount            float64     `bson:"amount" json:"amount"`
 	Base              VisionBase  `bson:"base" json:"base"`
 }
 type OtherVisionPrescription VisionPrescription


### PR DESCRIPTION
According to https://build.fhir.org/datatypes.html, `decimal` represents
"rational numbers that have a decimal representation". This type is
used, for example, for the `value` property in an Observation, as can be
seen in https://build.fhir.org/observation-example-f205-egfr.json.html.
Since the JSON does not have quotes around the value, Go fails to parse
it into a string. Using float64 for decimal seems appropriate.